### PR TITLE
General-assistant

### DIFF
--- a/src/api-wrapper/src/api/assistant/controllers/assistant.js
+++ b/src/api-wrapper/src/api/assistant/controllers/assistant.js
@@ -15,7 +15,7 @@ module.exports = createCoreController('api::assistant.assistant', ({ strapi }) =
       description,
       provinceId,
       serviceCategoryId,
-      isGeneral,
+      isGeneral = false,
     } = data.metaData || {};
 
     // Validate required fields


### PR DESCRIPTION
- Introduced an `isGeneral` flag in both the assistant and container controllers to differentiate between general and specific assistants.
- Modified validation logic to require service category and province only for non-general assistants.
- Adjusted endpoint generation in the container controller based on the assistant type, improving flexibility in handling requests.

These changes enhance the functionality and correctness of the assistant and container management processes.